### PR TITLE
linux-aarch64 build for nrpys

### DIFF
--- a/recipes/nrpys/meta.yaml
+++ b/recipes/nrpys/meta.yaml
@@ -38,7 +38,3 @@ about:
   license: AGPL-3.0-or-later
   license_file: LICENSE.txt
   summary: "Python language bindings for nrps-rs substrate specificity predictor."
-
-extra:
-  additional-platforms:
-    - linux-aarch64       # openEuler-22.03-SP3 aarch64

--- a/recipes/nrpys/meta.yaml
+++ b/recipes/nrpys/meta.yaml
@@ -8,6 +8,7 @@ package:
 
 build:
   number: 4
+  noarch: python
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin="x.x") }}
 


### PR DESCRIPTION
![nrpys](https://github.com/user-attachments/assets/708328af-2850-4f8b-a457-42e983b7d62f)
