### PR TITLE
linux-aarch64 aarch64 build for nrpys

### DIFF
--- a/recipes/nrpys/meta.yaml
+++ b/recipes/nrpys/meta.yaml
@@ -20,6 +20,8 @@ source:
     - pyproject.patch
 
 requirements:
+  build:
+    - python 3.9.*
   host:
     - python 3.9.*
     - pip


### PR DESCRIPTION
![nrpys](https://github.com/user-attachments/assets/580aab14-0ca3-447f-a443-163e0a999184)
