### PR TITLE
linux-aarch64 build for eggnog-mapper

### DIFF
--- a/recipes/eggnog-mapper/meta.yaml
+++ b/recipes/eggnog-mapper/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b3c53fb0e606a5cfec75cbc84f7c215f57f43ce00d8e50f449513acdad76da73
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage("eggnog-mapper", max_pin="x") }}
   noarch: python
@@ -53,9 +53,6 @@ about:
   doc_url: https://github.com/eggnogdb/eggnog-mapper/wiki
 
 extra:
-  additional-platforms:
-    - linux-aarch64
-
   container:
     # need wget with more options than the busybox one
     extended-base: True


### PR DESCRIPTION
![003](https://github.com/user-attachments/assets/6d762bb7-de9d-4d25-8e43-c8ffb85ab3d7)
