### PR TITLE
linux-aarch64 aarch64 build for nrpys

### DIFF
--- a/recipes/nrpys/meta.yaml
+++ b/recipes/nrpys/meta.yaml
@@ -21,11 +21,11 @@ source:
 
 requirements:
   build:
+    - rust
     - python 3.9.*
   host:
     - python 3.9.*
     - pip
-    - rust
     - maturin
     - zlib
   run:


### PR DESCRIPTION
![nrpys](https://github.com/user-attachments/assets/115bc703-85e2-4574-9a87-082cffe8b853)
