### PR TITLE
Updated linux-aarch64 build for nrpys

### DIFF
--- a/recipes/nrpys/meta.yaml
+++ b/recipes/nrpys/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 4
+  number: 5
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin="x.x") }}
 
@@ -23,12 +23,12 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
   host:
-    - python 3.9.*
+    - python <3.12
     - pip
     - maturin
     - zlib
   run:
-    - python 3.9.*
+    - python <3.12
 
 test:
   imports:


### PR DESCRIPTION
![nrpys](https://github.com/user-attachments/assets/2932aafd-bb73-48bc-a5a6-50a8bf153b7c)
