### PR TITLE
linux-aarch64 build for coverm

### DIFF
--- a/recipes/coverm/meta.yaml
+++ b/recipes/coverm/meta.yaml
@@ -18,10 +18,10 @@ source:
 
 requirements:
   build:
-    - rust >=1.37.0
+    - {{ compiler('rust') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - {{ stdlib("c") }}
+    - clangdev  #  one of the rust submodules explicitly requires clang. As it's statically compiled that will hopefully work
     - pkg-config
     - make
     - cmake


### PR DESCRIPTION
![008](https://github.com/user-attachments/assets/cb16440d-1e60-47b6-b33c-84320278ffdb)
