### PR TITLE
linux-aarch64 build for magpurify

### DIFF
--- a/recipes/magpurify/meta.yaml
+++ b/recipes/magpurify/meta.yaml
@@ -52,3 +52,8 @@ about:
   license_family: GPL
   license_file: LICENSE
   summary: "Identify and remove incorrectly binned contigs from metagenome-assembled genomes."
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+  


### PR DESCRIPTION
![009](https://github.com/user-attachments/assets/a37fbacc-fc45-47b4-b04a-2b166e720cc4)
