### PR TITLE
linux-aarch64 build for magpurify

### DIFF
--- a/recipes/magpurify/meta.yaml
+++ b/recipes/magpurify/meta.yaml
@@ -15,7 +15,7 @@ build:
     - magpurify=magpurify.cli:cli
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   run_exports:
-    - {{ pin_subpackage('dashing2', max_pin="x.x") }}
+    - {{ pin_subpackage('magpurify', max_pin="x.x") }}
 
 requirements:
   host:


### PR DESCRIPTION
![009](https://github.com/user-attachments/assets/80c76516-ffec-4d35-a745-95d62a311fb3)
