### PR TITLE
linux-aarch64 build for magpurify

### DIFF
--- a/recipes/magpurify/meta.yaml
+++ b/recipes/magpurify/meta.yaml
@@ -10,7 +10,6 @@ source:
 
 build:
   number: 2
-  skip: True # [osx]  
   noarch: python
   entry_points:
     - magpurify=magpurify.cli:cli


### PR DESCRIPTION
![009](https://github.com/user-attachments/assets/f1e91e79-d17d-422b-b04d-9e54f7b0722c)
