### PR TITLE
update peregrine-2021 and enabled linux-aarch64 

### DIFF
--- a/recipes/peregrine-2021/meta.yaml
+++ b/recipes/peregrine-2021/meta.yaml
@@ -17,8 +17,8 @@ source:
 
 requirements:
   build:
-    - {{ compiler('c') }} ==9.4.0
-    - {{ compiler('cxx') }} ==9.4.0
+    - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
     - rust >=1.58.0,<2.0.0
     - sed
   host:


### PR DESCRIPTION
<img width="1671" height="918" alt="peregrine-2021" src="https://github.com/user-attachments/assets/9c329d84-526b-46a7-8684-9c14176b03e2" />
