### PR TITLE
update peregrine-2021 and enabled linux-aarch64 

### DIFF
--- a/recipes/peregrine-2021/meta.yaml
+++ b/recipes/peregrine-2021/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
-    - rust >=1.58.0,<2.0.0
+    - rust >=1.58.0
     - sed
   host:
   run:


### PR DESCRIPTION
<img width="1671" height="918" alt="peregrine-2021" src="https://github.com/user-attachments/assets/1c322aca-6b0f-4d49-9c5e-560c4e939f5a" />
